### PR TITLE
Add Rising Flood challenge

### DIFF
--- a/src/challenge_explainations.py
+++ b/src/challenge_explainations.py
@@ -141,6 +141,62 @@ def challenge_done_screen_rotation_limit():
             if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
                 waiting = False
 
+
+def challenge_explanation_screen_rising_flood(interval_seconds: float) -> None:
+    """Intro screen for the Rising Flood (Garbage-Rush) challenge."""
+    pygame.display.get_surface().fill(BLACK)
+
+    title = fontTitle.render("Challenge: Rising Flood", True, WHITE)
+    _center(title, DISPLAY_HEIGHT // 5)
+
+    interval_text = int(round(interval_seconds))
+    lines = [
+        f"Alle {interval_text} Sekunden drückt eine Müllreihe das Feld nach oben.",
+        "Sie lässt nur ein zufälliges Loch frei.",
+        "Ist die oberste Reihe schon belegt, bedeutet die Flut Game Over.",
+        "Rechts findest du Countdown und Anzahl der Flutreihen.",
+        "Drücke ENTER, um zu starten.",
+    ]
+
+    y = DISPLAY_HEIGHT // 3
+    for txt in lines:
+        surf = fontSmall.render(txt, True, WHITE)
+        _center(surf, y)
+        y += 40
+
+    pygame.display.flip()
+
+    waiting = True
+    while waiting:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                raise SystemExit
+            if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+                waiting = False
+
+
+def challenge_done_screen_rising_flood() -> None:
+    """Simple completion screen after surviving the Rising Flood challenge."""
+    pygame.display.get_surface().fill(BLACK)
+
+    title = fontTitle.render("Rising Flood geschafft!", True, WHITE)
+    _center(title, DISPLAY_HEIGHT // 2 - 30)
+
+    hint = fontSmall.render("Drücke ENTER, um weiterzumachen.", True, WHITE)
+    _center(hint, DISPLAY_HEIGHT // 2 + 30)
+
+    pygame.display.flip()
+
+    waiting = True
+    while waiting:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                raise SystemExit
+            if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+                waiting = False
+
 def challenge_done_screen():
     # Clear the screen
     gameDisplay.fill(BLACK)

--- a/src/challenge_rising_flood.py
+++ b/src/challenge_rising_flood.py
@@ -1,0 +1,135 @@
+"""Challenge mode: Rising Flood (Garbage-Rush).
+
+Periodically injects a garbage row from the bottom that pushes the field
+upwards. A countdown shows when the next flood arrives and how many rows have
+already risen. If the stack (or active piece) touches the top when the flood
+hits, the game ends immediately.
+"""
+
+from __future__ import annotations
+
+import math
+
+from MainBoard import MainBoard
+from src.config import fontSB, TEXT_COLOR, NUM_COLOR
+from src.shared import gameDisplay, rng
+
+
+class Challenge_Rising_Flood(MainBoard):
+    """MainBoard variant with periodic garbage rows rising from below."""
+
+    _frames_per_second = 60
+
+    def __init__(
+        self,
+        starting_level: int,
+        score: int,
+        flood_interval_seconds: float = 12.0,
+        upgrades: dict | None = None,
+    ) -> None:
+        super().__init__(starting_level, score, upgrades)
+        self.flood_interval_seconds = max(1.0, float(flood_interval_seconds))
+        self.flood_interval_frames = max(
+            1, int(self.flood_interval_seconds * self._frames_per_second)
+        )
+        self.frames_until_next_flood = self.flood_interval_frames
+        self.flood_rows_added = 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    # ------------------------------------------------------------------
+
+    def restart(self) -> None:
+        super().restart()
+        self.frames_until_next_flood = self.flood_interval_frames
+        self.flood_rows_added = 0
+
+    def gameAction(self) -> None:  # type: ignore[override]
+        super().gameAction()
+        if self.gameStatus == 'running' and not self.gamePause:
+            self._update_flood_timer()
+
+    # ------------------------------------------------------------------
+    # Flood mechanics
+    # ------------------------------------------------------------------
+
+    def _update_flood_timer(self) -> None:
+        if self.frames_until_next_flood > 0:
+            self.frames_until_next_flood -= 1
+
+        if self.frames_until_next_flood <= 0:
+            flooded = self._trigger_flood()
+            if self.gameStatus == 'gameOver':
+                return
+            if flooded:
+                self.frames_until_next_flood = self.flood_interval_frames
+            else:
+                # try again shortly (e.g. while a line clear animation runs)
+                self.frames_until_next_flood = 1
+
+    def _trigger_flood(self) -> bool:
+        # Avoid conflicting with the line clear animation – try again shortly.
+        if self.lineClearStatus != 'idle':
+            return False
+
+        # If the top row already contains blocks, the rising flood ends the game.
+        if any(cell != 'empty' for cell in self.blockMat[0]):
+            self.gameStatus = 'gameOver'
+            return False
+
+        # Active piece reaches the ceiling – cannot raise the board safely.
+        if self.piece.status == 'moving':
+            if any(block.currentPos.row <= 0 for block in self.piece.blocks):
+                self.gameStatus = 'gameOver'
+                return False
+
+        self._raise_board()
+        return True
+
+    def _raise_board(self) -> None:
+        # Push the locked stack upwards by one row.
+        for row in range(self.rowNum - 1):
+            self.blockMat[row] = list(self.blockMat[row + 1])
+
+        # Inject new garbage row with a random hole at the bottom.
+        hole_col = rng.randint(0, self.colNum - 1)
+        new_row = ['garbage'] * self.colNum
+        new_row[hole_col] = 'empty'
+        self.blockMat[self.rowNum - 1] = new_row
+
+        self.flood_rows_added += 1
+
+        # Move the active piece one row up to match the rising stack.
+        if self.piece.status == 'moving':
+            for block in self.piece.blocks:
+                block.currentPos.row -= 1
+                block.nextPos.row = block.currentPos.row
+
+    # ------------------------------------------------------------------
+    # Scoreboard overlay
+    # ------------------------------------------------------------------
+
+    def draw_score_content(self, xPosRef: int, yLastBlock: int) -> None:
+        scoreText = fontSB.render('score:', False, TEXT_COLOR)
+        gameDisplay.blit(scoreText, (xPosRef + self.blockSize, yLastBlock - 12 * self.blockSize))
+        scoreNumText = fontSB.render(str(self.score), False, NUM_COLOR)
+        gameDisplay.blit(scoreNumText, (xPosRef + self.blockSize, yLastBlock - 10 * self.blockSize))
+
+        levelText = fontSB.render('level:', False, TEXT_COLOR)
+        gameDisplay.blit(levelText, (xPosRef + self.blockSize, yLastBlock - 8 * self.blockSize))
+        levelNumText = fontSB.render(str(self.level), False, NUM_COLOR)
+        gameDisplay.blit(levelNumText, (xPosRef + self.blockSize, yLastBlock - 6 * self.blockSize))
+
+        floodText = fontSB.render('flood in:', False, TEXT_COLOR)
+        gameDisplay.blit(floodText, (xPosRef + self.blockSize, yLastBlock - 4 * self.blockSize))
+        seconds_left = max(
+            0,
+            math.ceil(self.frames_until_next_flood / self._frames_per_second),
+        )
+        floodValue = fontSB.render(f'{seconds_left}s', False, NUM_COLOR)
+        gameDisplay.blit(floodValue, (xPosRef + self.blockSize, yLastBlock - 3 * self.blockSize))
+
+        raisedText = fontSB.render('rows risen:', False, TEXT_COLOR)
+        gameDisplay.blit(raisedText, (xPosRef + self.blockSize, yLastBlock - 2 * self.blockSize))
+        raisedValue = fontSB.render(str(self.flood_rows_added), False, NUM_COLOR)
+        gameDisplay.blit(raisedValue, (xPosRef + self.blockSize, yLastBlock - 1 * self.blockSize))

--- a/src/config.py
+++ b/src/config.py
@@ -38,13 +38,15 @@ NUM_COLOR = WHITE
 TEXT_COLOR = GRAY
 
 blockColors = {
-'I' : (19,232,232), #CYAN
-'O' : (236,236,14), #YELLOW
-'T' : (126,5,126), #PURPLE
-'S' : (0,128,0), #GREEN
-'Z' : (236,14,14), #RED
-'J' : (30,30,201), #BLUE
-'L' : (240,110,2) } #ORANGE
+    'I': (19, 232, 232),  # CYAN
+    'O': (236, 236, 14),  # YELLOW
+    'T': (126, 5, 126),  # PURPLE
+    'S': (0, 128, 0),  # GREEN
+    'Z': (236, 14, 14),  # RED
+    'J': (30, 30, 201),  # BLUE
+    'L': (240, 110, 2),  # ORANGE
+    'garbage': (90, 90, 90),
+}
 
 #Initial(spawn) block definitons of each piece
 pieceDefs = {

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from challenge_spin import Challenge_Spin
 import os
 
 from src.challenge_rotation_limit import Challenge_Rotation_Limit
+from src.challenge_rising_flood import Challenge_Rising_Flood
 from src.upgrades import load_upgrades, save_upgrades
 
 
@@ -237,8 +238,21 @@ if __name__ == '__main__':
                 continue
             challenge_done_screen_rotation_limit()
 
+            # Challenge: Rising Flood (Garbage-Rush)
+            flood_interval = 12
+            challenge_explanation_screen_rising_flood(flood_interval)
+            current_board = Challenge_Rising_Flood(
+                12,
+                current_board.score,
+                flood_interval_seconds=flood_interval,
+                upgrades=upgrades_data,
+            )
+            if gameLoop(name=name, target_level=15, mainBoard=current_board):
+                continue
+            challenge_done_screen_rising_flood()
+
             # Wieder zurück zum Basisspiel (bis Level 50)
-            current_board = MainBoard(12, current_board.score, upgrades=upgrades_data)
+            current_board = MainBoard(15, current_board.score, upgrades=upgrades_data)
             if gameLoop(name=name, target_level=50, mainBoard=current_board):
                 continue
             break


### PR DESCRIPTION
## Summary
- add a Rising Flood challenge board that periodically raises garbage rows and shows countdown/row counters
- add explanation and completion screens plus wire the new challenge into the campaign flow
- register a garbage block color so the new rows render properly

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c97b186cc88333b92c4b175c73cdc4